### PR TITLE
Update navbar for mobile

### DIFF
--- a/src/_assets/script.js
+++ b/src/_assets/script.js
@@ -1,5 +1,5 @@
 /* Trigger the floating icon animations in the home section */
-const floatingIcons = document.querySelectorAll('svg.floating-icon')
+const floatingIcons = document.querySelectorAll('#home svg.floating-icon')
 const navElement = document.querySelector('nav')
 
 const wait = (callback, timeout) =>
@@ -16,37 +16,10 @@ for (let [index, floatingIcon] of floatingIcons.entries()) {
   }, index * 100 + 500)
 }
 
-/* Trigger animations when scrolling to a new section of the page */
-const observerOptions = {
-  root: null,
-  rootMargin: '-60% 0px -40% 0px', // trigger when 40% of the new section is visible on the page
-  threshold: 0,
-}
-
-const observerCallback = (events) => {
-  events.forEach((event) => {
-    if (event.isIntersecting) {
-      if (event.target.id === 'home') {
-        navElement.classList.remove('white')
-      } else {
-        navElement.classList.add('white')
-      }
-    }
-  })
-}
-
-let observer = new IntersectionObserver(observerCallback, observerOptions)
-
-for (let sectionId of ['home', 'about', 'team', 'listen']) {
-  observer.observe(document.getElementById(sectionId))
-}
-
-document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
-  anchor.addEventListener('click', function (e) {
-    e.preventDefault()
-
-    document.querySelector(this.getAttribute('href')).scrollIntoView({
-      behavior: 'smooth',
-    })
-  })
+document.addEventListener('scroll', (e) => {
+  if (window.scrollY > 60) {
+    navElement.classList.add('white')
+  } else {
+    navElement.classList.remove('white')
+  }
 })

--- a/src/_sass/_imports/nav.scss
+++ b/src/_sass/_imports/nav.scss
@@ -52,14 +52,18 @@ nav {
     margin: 0;
     padding: 0;
 
+    @media (max-width: $mobile-breakpoint) {
+      justify-content: space-between;
+    }
+
     li {
       margin: 0 30px;
       display: flex;
       align-items: center;
       position: relative;
 
-      @media (max-width: $mobile-breakpoint) {
-        margin: 0 20px;
+      @media (max-width: 500px) {
+        margin: 0 12px;
       }
 
       &:first-of-type {

--- a/src/_sass/_imports/nav.scss
+++ b/src/_sass/_imports/nav.scss
@@ -1,15 +1,5 @@
 @import 'variables.scss';
 
-@media (max-width: $mobile-breakpoint) {
-  $mobile-nav-height: 60px;
-  nav {
-    height: $mobile-nav-height;
-  }
-  main {
-    margin-top: $mobile-nav-height;
-  }
-}
-
 nav {
   height: $nav-height;
   z-index: 1;
@@ -23,7 +13,7 @@ nav {
 
   @media (max-width: $mobile-breakpoint) {
     font-size: 16px;
-    height: 60px;
+    height: $mobile-nav-height;
   }
 
   display: flex;

--- a/src/_sass/_imports/variables.scss
+++ b/src/_sass/_imports/variables.scss
@@ -9,3 +9,4 @@ $mobile-breakpoint: 600px;
 $tablet-breakpoint: 900px;
 
 $nav-height: 70px;
+$mobile-nav-height: 60px;

--- a/src/_sass/global.scss
+++ b/src/_sass/global.scss
@@ -24,6 +24,10 @@ body {
 main {
   margin-top: $nav-height;
   overflow: hidden;
+
+  @media (max-width: $mobile-breakpoint) {
+    margin-top: $mobile-nav-height;
+  }
 }
 
 h1,


### PR DESCRIPTION
A few small fixes:
- get rid of this visual bug: ![white gap between nav and main content](https://user-images.githubusercontent.com/31811199/106344698-66c9d400-6279-11eb-8455-88c6a6be078a.png)
- make margins between nav links a little smaller on mobile
- update nav background change on scroll to use a generic scroll event listener. The current implementation _only_ works on the home page. So as we add more pages, the background effect won't carry over.
